### PR TITLE
Add support multi-level sealed

### DIFF
--- a/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/generator/SealedTypeObjectPropertyGenerator.java
+++ b/fixture-monkey-api/src/main/java17/com/navercorp/fixturemonkey/api/generator/SealedTypeObjectPropertyGenerator.java
@@ -21,6 +21,8 @@ package com.navercorp.fixturemonkey.api.generator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -38,7 +40,7 @@ public final class SealedTypeObjectPropertyGenerator implements ObjectPropertyGe
 		double nullInject = context.getNullInjectGenerator().generate(context);
 
 		Map<Property, List<Property>> childPropertiesByProperty = new HashMap<>();
-		for (Class<?> subClass : actualType.getPermittedSubclasses()) {
+		for (Class<?> subClass : collectPermittedSubclasses(actualType).collect(Collectors.toSet())) {
 			Property subProperty = PropertyUtils.toProperty(subClass);
 
 			List<Property> subPropertyChildProperties = context.getPropertyGenerator()
@@ -54,5 +56,14 @@ public final class SealedTypeObjectPropertyGenerator implements ObjectPropertyGe
 			context.getElementIndex(),
 			childPropertiesByProperty
 		);
+	}
+
+	private static Stream<Class<?>> collectPermittedSubclasses(Class<?> type) {
+		if (type.isSealed()) {
+			return Stream.of(type.getPermittedSubclasses())
+				.flatMap(SealedTypeObjectPropertyGenerator::collectPermittedSubclasses);
+		} else {
+			return Stream.of(type);
+		}
 	}
 }

--- a/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/MultiLevelSealedClassTest.java
+++ b/fixture-monkey-tests/java-17-tests/src/test/java/com/navercorp/fixturemonkey/tests/java17/MultiLevelSealedClassTest.java
@@ -1,0 +1,106 @@
+/*
+ * Fixture Monkey
+ *
+ * Copyright (c) 2021-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.fixturemonkey.tests.java17;
+
+import static com.navercorp.fixturemonkey.tests.TestEnvironment.TEST_COUNT;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.beans.ConstructorProperties;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+
+class MultiLevelSealedClassTest {
+	private static final FixtureMonkey SUT = FixtureMonkey.builder()
+		.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+		.defaultNotNull(true)
+		.build();
+
+	private static sealed class SealedClass permits IntermediateSealedClass {
+	}
+
+	private static sealed class IntermediateSealedClass extends SealedClass permits SealedClassImpl {
+	}
+
+	private static final class SealedClassImpl extends IntermediateSealedClass {
+		private final String value;
+
+		@ConstructorProperties("value")
+		public SealedClassImpl(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleSealedClass() {
+		// when
+		SealedClass actual = SUT.giveMeOne(SealedClass.class);
+
+		then(actual).isInstanceOf(SealedClassImpl.class);
+	}
+
+	private sealed interface SealedInterface permits IntermediateSealedInterface {
+	}
+
+	private sealed interface IntermediateSealedInterface extends SealedInterface permits SealedInterfaceImpl {
+	}
+
+	private record SealedInterfaceImpl(String value) implements IntermediateSealedInterface {
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleSealedInterface() {
+		// when
+		SealedInterface actual = SUT.giveMeOne(SealedInterface.class);
+
+		then(actual).isInstanceOf(SealedInterface.class);
+	}
+
+	private record SealedClassProperty(
+		SealedClass sealedClass,
+		SealedInterface sealedInterface
+	) {
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void sampleSealedClassProperty() {
+		// when
+		SealedClassProperty actual = SUT.giveMeOne(SealedClassProperty.class);
+
+		then(actual.sealedInterface()).isInstanceOf(SealedInterfaceImpl.class);
+		then(actual.sealedClass()).isInstanceOf(SealedClassImpl.class);
+	}
+
+	@RepeatedTest(TEST_COUNT)
+	void fixedSealedClassProperty() {
+		// when
+		SealedClassProperty actual = SUT.giveMeBuilder(SealedClassProperty.class)
+			.fixed()
+			.sample();
+
+		then(actual.sealedInterface()).isInstanceOf(SealedInterfaceImpl.class);
+		then(actual.sealedClass()).isInstanceOf(SealedClassImpl.class);
+	}
+}


### PR DESCRIPTION
## Summary
Add support for multi-level inheritance of sealed class and sealed interface.

## How Has This Been Tested?
Add a new test that adds an intermediate inherited class and interface to an existing test.
